### PR TITLE
chore(config): carregar variáveis do .env e preencher .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Banco de Dados
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_NAME=seu_banco
+DATABASE_USER=seu_usuario
+DATABASE_PASSWORD=sua_senha
+DATABASE_SSLMODE=disable
+
+# API
+API_PORT=9000

--- a/config/config.go
+++ b/config/config.go
@@ -9,11 +9,15 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// Config armazena as configurações essenciais para a aplicação,
+// incluindo dados de conexão e porta do servidor.
 type Config struct {
 	ConnectionString string
 	Port             int
 }
 
+// NewConfig carrega as configurações da aplicação a partir do arquivo .env
+// e variáveis de ambiente, aplicando valores padrão quando necessário.
 func NewConfig() (*Config, error) {
 	if err := godotenv.Load(); err != nil {
 		return nil, fmt.Errorf("erro ao carregar .env: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -1,1 +1,42 @@
 package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/joho/godotenv"
+)
+
+type Config struct {
+	ConnectionString string
+	Port             int
+}
+
+func NewConfig() (*Config, error) {
+	if err := godotenv.Load(); err != nil {
+		return nil, fmt.Errorf("erro ao carregar .env: %v", err)
+	}
+
+	port, err := strconv.Atoi(os.Getenv("API_PORT"))
+	if err != nil {
+		port = 9000
+	}
+
+	password := url.QueryEscape(os.Getenv("DATABASE_PASSWORD"))
+
+	connectionString := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
+		os.Getenv("DATABASE_USER"),
+		password,
+		os.Getenv("DATABASE_HOST"),
+		os.Getenv("DATABASE_PORT"),
+		os.Getenv("DATABASE_NAME"),
+		os.Getenv("DATABASE_SSLMODE"),
+	)
+
+	return &Config{
+		ConnectionString: connectionString,
+		Port:             port,
+	}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/brenodsm/gobalance-api
 
 go 1.24.2
+
+require github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=


### PR DESCRIPTION
## Descrição

Este PR adiciona o carregamento das variáveis de ambiente e preenche o arquivo `.env.example` com as configurações necessárias para a aplicação.

* Implementa a função `NewConfig` em `config/config.go` para ler variáveis do `.env` usando `godotenv`.
* Monta a connection string do PostgreSQL, escapando a senha (`DATABASE_PASSWORD`) e incluindo o parâmetro `sslmode` configurável.
* Define fallback para `API_PORT` como `9000` quando não informado.
* Preenche o `.env.example` com todas as variáveis obrigatórias para conectar ao banco e iniciar o servidor.

---

## Motivação

Garantir que a aplicação carregue corretamente suas configurações essenciais em diferentes ambientes (desenvolvimento, homologação e produção), evitando erros de inicialização e documentando de forma clara quais variáveis são necessárias.

---

## Alterações

* **config/config.go**

  * Nova função `NewConfig()` para carregar e validar variáveis de ambiente.
  * Uso de `url.QueryEscape` para a senha do banco.
  * Fallback em `API_PORT`.

* **.env.example**

  * Adicionadas variáveis:

    * `DATABASE_HOST`
    * `DATABASE_PORT`
    * `DATABASE_NAME`
    * `DATABASE_USER`
    * `DATABASE_PASSWORD`
    * `DATABASE_SSLMODE`
    * `API_PORT`

---

## Checklist

* [x] Função `NewConfig` implementada para leitura de `.env`.
* [x] Connection string do PostgreSQL corretamente formatada e segura.
* [x] Fallback de porta definido.
* [x] `.env.example` preenchido com todas as variáveis necessárias.