### PR TITLE
feat(response): adicionar funções WriteJSON e WriteErrorJSON para respostas JSON padronizadas

### DIFF
--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -1,1 +1,30 @@
 package response
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// WriteJSON envia uma resposta HTTP com status e dados serializados em JSON.
+func WriteJSON(w http.ResponseWriter, statusCode int, data any) {
+	if data == nil {
+		w.WriteHeader(statusCode)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("Erro ao serializar em JSON: %v\n", err)
+	}
+}
+
+// WriteErrorJSON envia uma resposta de erro HTTP no formato JSON.
+func WriteErrorJSON(w http.ResponseWriter, statusCode int, err error) {
+	WriteJSON(w, statusCode, struct {
+		Error string `json:"error"`
+	}{
+		Error: err.Error(),
+	})
+}


### PR DESCRIPTION
## Descrição

Este PR adiciona um pacote `response` responsável por enviar respostas HTTP em JSON de forma padronizada.

* Implementa a função `WriteJSON` para enviar dados serializados em JSON com o status HTTP configurado.
* Implementa a função `WriteErrorJSON` para enviar respostas de erro no formato JSON com o campo `"error"`.
* Centraliza e padroniza o envio de respostas JSON na API, facilitando a manutenção e leitura dos handlers.

---

## Motivação

Melhorar a consistência e legibilidade dos handlers da API, reduzindo repetição de código e garantindo respostas JSON uniformes, o que facilita o consumo pelo frontend e clientes da API.

---

## Alterações

- Criação do arquivo `response/response.go`.
- Adição da função `WriteJSON(w http.ResponseWriter, statusCode int, data any)`.
- Adição da função `WriteErrorJSON(w http.ResponseWriter, statusCode int, err error)`.

---

## Checklist

* [x] Implementação correta do cabeçalho `Content-Type: application/json`.
* [x] Serialização segura e eficiente dos dados em JSON.
* [x] Tratamento e log de erros na serialização.
