### PR TITLE
feat(repository): implementa criação de usuário no banco de dados

### DIFF
--- a/internal/user/repository/repository.go
+++ b/internal/user/repository/repository.go
@@ -1,1 +1,37 @@
 package repository
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/brenodsm/gobalance-api/internal/user/model"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ErrUserAlreadyRegister indica que o usuário já está cadastrado no sistema.
+var ErrUserAlreadyRegister error = errors.New("usuário já cadastrado")
+
+// userRepository implementa operações de acesso a dados para usuários.
+type userRepository struct {
+	db *sql.DB
+}
+
+// NewUserRepository cria e retorna um novo repositório de usuários.
+func NewUserRepository(db *sql.DB) *userRepository {
+	return &userRepository{db}
+}
+
+// Create insere um novo usuário no banco de dados e retorna seu ID.
+func (u *userRepository) Create(user model.User) (uint64, error) {
+	var id uint64
+	query := "INSERT INTO users (name, email, password) VALUES ($1, $2, $3) RETURNING id"
+	err := u.db.QueryRow(query, user.Name, user.Email, user.Password).Scan(&id)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return 0, ErrUserAlreadyRegister
+		}
+		return 0, err
+	}
+	return id, nil
+}


### PR DESCRIPTION
## Descrição

Este PR adiciona um repositório responsável por realizar a criação de novos usuários no banco de dados PostgreSQL.

* Implementa o `userRepository` com dependência de `*sql.DB`.
* Cria a função `Create`, que insere um novo usuário e retorna o ID gerado.
* Adiciona tratamento de erro para duplicidade de e-mail (`PostgreSQL error code 23505`), retornando o erro semântico `ErrUserAlreadyRegister`.

---

## Motivação

Encapsular a lógica de acesso ao banco de dados referente à criação de usuários, separando responsabilidades e promovendo uma arquitetura mais modular, testável e de fácil manutenção.

---

## Alterações

- Criação do pacote `repository`.
- Criação da struct `userRepository`.
- Implementação da função `Create(user model.User) (uint64, error)`.
- Adição do erro semântico `ErrUserAlreadyRegister` para tratar casos de e-mail duplicado.

---

## Checklist

- [x] Repositório implementado com injeção de dependência via `*sql.DB`
- [x] Execução do `INSERT` com `RETURNING id` validada
- [x] Tratamento de erro de chave única (`23505`) implementado corretamente
