### PR TITLE
feat(service): adiciona validações, sanitização e hash de senha no cadastro de usuário

### DIFF
--- a/internal/user/service/user_service.go
+++ b/internal/user/service/user_service.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/badoux/checkmail"
+	"github.com/brenodsm/gobalance-api/internal/user/model"
+	"github.com/brenodsm/gobalance-api/internal/user/security"
+)
+
+// userService contém regras de negócio relacionadas a usuários.
+type userService struct{}
+
+// NewUserService cria e retorna uma instância de userService.
+func NewUserService() *userService {
+	return &userService{}
+}
+
+// Register aplica validações e sanitiza os dados do usuário antes do cadastro.
+func (u *userService) Register(user *model.User) error {
+	u.sanitizeUserInput(user)
+	if err := u.validate(user); err != nil {
+		return err
+	}
+
+	if err := u.validatePassword(user.Password); err != nil {
+		return err
+	}
+
+	if err := u.hashPassword(user); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validate verifica se os campos obrigatórios do usuário estão preenchidos e se o e-mail é válido.
+func (u *userService) validate(user *model.User) error {
+	if user.Name == "" {
+		return errors.New("o nome não pode estar em branco")
+	}
+	if user.Email == "" {
+		return errors.New("o email não pode estar em branco")
+	}
+	if err := checkmail.ValidateFormat(user.Email); err != nil {
+		return errors.New("email inválido")
+	}
+	if user.Password == "" {
+		return errors.New("a senha não pode estar em branco")
+	}
+	return nil
+}
+
+// validatePassword verifica se a senha atende aos requisitos mínimos de segurança.
+func (u *userService) validatePassword(password string) error {
+	if len(password) < 8 {
+		return errors.New("a senha deve ter no mínimo 8 caracteres")
+	}
+	for _, l := range password {
+		if l == ' ' {
+			return errors.New("a senha não pode conter espaços")
+		}
+	}
+	return nil
+}
+
+// sanitizeUserInput padroniza os campos de entrada do usuário, removendo espaços em branco.
+func (u *userService) sanitizeUserInput(user *model.User) {
+	user.Name = strings.TrimSpace(user.Name)
+	user.Email = strings.TrimSpace(user.Email)
+	user.Password = strings.TrimSpace(user.Password)
+}
+
+// hashPassword gera o hash da senha e substitui o valor original no modelo do usuário.
+func (u *userService) hashPassword(user *model.User) error {
+	hash, err := security.Hash(user.Password)
+	if err != nil {
+		return err
+	}
+	user.Password = hash
+	return nil
+}


### PR DESCRIPTION
## Descrição

Este PR implementa a camada de `service` responsável por aplicar regras de negócio durante o processo de cadastro de usuários.

* Implementa a função `Register`, que:
  - Sanitiza os dados de entrada do usuário.
  - Valida os campos obrigatórios e o formato do e-mail.
  - Verifica os critérios mínimos de segurança da senha.
  - Gera um hash da senha utilizando bcrypt antes do armazenamento.
* Centraliza regras de negócio para promover reuso e organização da lógica de validação.

---

## Motivação

- Separar a lógica de negócios do controle HTTP e da persistência de dados, promovendo **encapsulamento, reutilização e testabilidade**. 
- Isso melhora a manutenibilidade da aplicação e facilita a aplicação de testes unitários e de integração.

---

## Alterações

- Criação do pacote `service`.
- Implementação da struct `userService` com o método `Register`.
- Validação de campos obrigatórios (`Name`, `Email`, `Password`).
- Validação de formato de e-mail com a lib `checkmail`.
- Verificação da força mínima da senha.
- Sanitização de campos via `strings.TrimSpace`.
- Geração de hash de senha com `security.Hash`.

---

## Checklist

- [x] Método `Register` implementado com validações e sanitização
- [x] Validação de e-mail com `checkmail.ValidateFormat`
- [x] Regras de senha mínima de 8 caracteres e sem espaços
- [x] Hash de senha gerado com bcrypt
