### PR TITLE
feat(handler): implementa HandlerCreateUser para registrar novo usuário via HTTP

### DIFF
--- a/internal/user/handler/handler.go
+++ b/internal/user/handler/handler.go
@@ -1,1 +1,48 @@
 package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/brenodsm/gobalance-api/internal/database"
+	"github.com/brenodsm/gobalance-api/internal/response"
+	"github.com/brenodsm/gobalance-api/internal/user/model"
+	"github.com/brenodsm/gobalance-api/internal/user/repository"
+	"github.com/brenodsm/gobalance-api/internal/user/service"
+)
+
+// HandlerCreateUser trata requisições HTTP para registrar um novo usuário.
+func HandlerCreateUser(w http.ResponseWriter, r *http.Request) {
+	var user model.User
+	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+		response.WriteErrorJSON(w, http.StatusBadRequest, err)
+		return
+	}
+	db, err := database.OpenConnection()
+	if err != nil {
+		response.WriteErrorJSON(w, http.StatusInternalServerError, err)
+		return
+	}
+	defer db.Close()
+
+	userService := service.NewUserService()
+	if err := userService.Register(&user); err != nil {
+		response.WriteErrorJSON(w, http.StatusBadRequest, err)
+		return
+	}
+
+	repo := repository.NewUserRepository(db)
+	id, err := repo.Create(user)
+	if err != nil {
+		if errors.Is(err, repository.ErrUserAlreadyRegister) {
+			response.WriteErrorJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+		response.WriteErrorJSON(w, http.StatusConflict, err)
+		return
+	}
+	w.Header().Set("Location", fmt.Sprintf("/users/%d", id))
+	response.WriteJSON(w, http.StatusCreated, id)
+}


### PR DESCRIPTION
## Descrição

Este PR implementa o handler `HandlerCreateUser`, responsável por tratar requisições HTTP para o cadastro de novos usuários.

* Decodifica o corpo da requisição JSON para um objeto `User`.
* Realiza validação e sanitização via `userService.Register`.
* Persiste o usuário no banco via `userRepository.Create`.
* Trata erros semânticos (e-mail duplicado) e erros de infraestrutura.
* Define o cabeçalho `Location` com o ID do recurso criado.
* Retorna `201 Created` com o ID do usuário.

---

## Motivação

Fornecer um ponto de entrada HTTP para criação de usuários na aplicação, garantindo separação entre camadas (handler, service, repository) e padronização de respostas para clientes da API.

---

## Alterações

- Criação da função `HandlerCreateUser(w http.ResponseWriter, r *http.Request)`
- Integração com `service.UserService` para validação e hash
- Integração com `repository.UserRepository` para persistência
- Retorno padronizado de erros e sucesso com o pacote `response`

---

## Checklist

- [x] JSON do corpo da requisição decodificado corretamente
- [x] Dados do usuário validados, sanitizados e com senha hasheada
- [x] Erro tratado para e-mails já cadastrados
- [x] Requisição bem-sucedida retorna `201 Created` com cabeçalho `Location`
- [x] Handler isolado e aderente à arquitetura da aplicação