### PR TITLE
feat(router): adiciona rota POST /users para criação de usuário

### DIFF
--- a/internal/user/router/router.go
+++ b/internal/user/router/router.go
@@ -1,1 +1,13 @@
 package router
+
+import (
+	"github.com/brenodsm/gobalance-api/internal/user/handler"
+	"github.com/go-chi/chi/v5"
+)
+
+// UserRoutes monta todas as rotas relacionadas a usuários no roteador fornecido.
+func UserRoute(r chi.Router) {
+	r.Route("/users", func(r chi.Router) {
+		r.Post("/", handler.HandlerCreateUser)
+	})
+}


### PR DESCRIPTION
## Descrição

Este PR adiciona a rota `POST /users` ao roteador principal, responsável por receber requisições para a criação de novos usuários.

* A rota está registrada dentro do escopo `/users`.
* Conecta a rota ao handler `HandlerCreateUser`, que lida com o processamento e persistência do usuário.

---

## Motivação

Expor a funcionalidade de cadastro de usuários via API HTTP de forma organizada, seguindo a arquitetura REST e centralizando as rotas por domínio (`/users`).

---

## Alterações

- Criação da função `UserRoute(r chi.Router)` no pacote `router`
- Registro da rota `POST /users` com o handler `HandlerCreateUser`

---

## Checklist

- [x] Rota `POST /users` registrada corretamente
- [x] Handler conectado à rota
- [x] Estrutura RESTful mantida
